### PR TITLE
make naming conventions match that of other libs

### DIFF
--- a/vdom/core.py
+++ b/vdom/core.py
@@ -34,26 +34,71 @@ class VDOM():
         }
 
 
-def createElement(tagName):
-    """Take an HTML tag and create an element"""
+def createComponent(tagName):
+    """Create a component for an HTML Tag
 
-    class VDOMEl():
-        """A basic class for a virtual DOM element"""
+    Examples:
+        >>> marquee = createComponent('marquee')
+        >>> marquee('woohoo')
+        <marquee>woohoo</marquee>
+
+    """
+
+    class Component():
+        """A basic class for a virtual DOM Component"""
         def __init__(self, children=None, **kwargs):
             self.children = children
             self.attributes = kwargs
             self.tagName = tagName
 
         def _repr_mimebundle_(self, include, exclude, **kwargs):
-            return VDOM(self)
+            return {
+                'application/vdom.v1+json': toJSON(self)
+            }
 
-    return VDOMEl
+    return Component
+
+def createElement(tagName):
+    """Takes an HTML tag and creates a VDOM Component
+
+    WARNING: This call is deprecated, as the name is the same as React.createElement
+    while having an entirely different meaning.
+
+    This is written more like a helper, similar to https://github.com/ohanhi/hyperscript-helpers
+    allowing you to create code like
+
+    div([
+      p('hey')
+    ])
+
+    Instead of writing
+
+    h('div', [
+        h('p', 'hey')
+    ])
+
+    This should have been written more like React.createClass
+    """
+    print("Warning: createElement is deprecated in favor of createComponent")
+    return createComponent(tagName)
+
+def h(tagName, children=None, attrs=None, **kwargs):
+    """Takes an HTML Tag, children (string, array, or another element), and attributes
+
+    Examples:
+
+      >>> h('div', [h('p', 'hey')])
+      <div><p>hey</p></div>
+
+    """
+    if attrs is None:
+        attrs={}
+    el = createComponent(tagName)
+    return el(children, **attrs, **kwargs)
 
 
-# This deserves some bonafide metaprogramming
-# We'll just get started creating some elements for now
-h1 = createElement('h1')
-p = createElement('p')
-div = createElement('div')
-img = createElement('img')
-b = createElement('b')
+h1 = createComponent('h1')
+p = createComponent('p')
+div = createComponent('div')
+img = createComponent('img')
+b = createComponent('b')


### PR DESCRIPTION
This cleans up probably the biggest misstep I could have made when starting this which was making a function called `createElement` that doesn't actually create the VDOM Element. It creates something more similar to creating a component which can create elements later (it's a factory...).

This PR introduces a few new functions and "deprecates" the old usage (it's only been a week, but I might as well be kind).

# New Functions

## `createComponent`

`createComponent` is exactly the same as what `createElement` did before, with a better name.

```python
>>> marquee = createComponent('marquee')
>>> marquee('woohoo')
<marquee>woohoo</marquee>
```

## `h`

> Wait, did you pick a single letter for a function Kyle?

Yes, yes I did. Ok, it's not me. This comes by way of [`preact`](https://github.com/developit/preact#rendering-jsx) and [`hyperscript`](https://github.com/hyperhype/hyperscript), allowing you to write condense `React.createElement` style writing:

```python
>>> h('div', [h('p', 'hey')])
<div><p>hey</p></div>
```

We don't have JSX in Python, so this is the closest we can really get. :wink:

# Helpers

The `h1`, `img`, and other HTML elements are still created here, they're left alone for backwards compatibility.  These were put in to be similar to [hyperscript-helpers](https://github.com/ohanhi/hyperscript-helpers).

# Bug fix

Prior to this, you had to wrap VDOMEls in a call to `VDOM()`. That's no more, as they provide the repr properly now:

<img width="777" alt="screen shot 2017-09-22 at 8 11 32 am" src="https://user-images.githubusercontent.com/836375/30751283-bb599302-9f6d-11e7-918b-318e95739034.png">

/cc @mpacer 