### PR TITLE
add a schema keyword to toJSON so that schemas can be tested more easily

### DIFF
--- a/vdom/core.py
+++ b/vdom/core.py
@@ -8,8 +8,17 @@ vdom.core
 This module provides the core implementation for the VDOM (Virtual DOM).
 
 """
-def toJSON(el):
+
+from jsonschema import validate, Draft4Validator, ValidationError
+
+def toJSON(el, schema=None):
     """Convert an element to JSON"""
+    if schema:
+        try:
+            validate(instance=el, schema=schema, cls=Draft4Validator)
+        except ValidationError as e:
+            raise ValidationError("Your object didn't match the schema: {}. \n {}".format(schema, e))
+
     if(type(el) is str):
         return el
     if(type(el) is list):

--- a/vdom/core.py
+++ b/vdom/core.py
@@ -12,7 +12,6 @@ This module provides the core implementation for the VDOM (Virtual DOM).
 from jsonschema import validate, Draft4Validator, ValidationError
 
 def toJSON(el, schema=None):
-    """Convert an element to JSON"""
     if schema:
         try:
             validate(instance=el, schema=schema, cls=Draft4Validator)
@@ -21,6 +20,11 @@ def toJSON(el, schema=None):
 
     if(type(el) is str):
         return el
+    """Convert an element to JSON
+
+    If you wish to validate the JSON, pass in a schema via the schema keyword argument.
+    If a schema is provided, this raises a ValidationError if JSON does not match the schema.
+    """
     if(type(el) is list):
         return list(map(toJSON, el))
     if(hasattr(el, 'tagName') and hasattr(el, 'attributes')):

--- a/vdom/core.py
+++ b/vdom/core.py
@@ -12,28 +12,29 @@ This module provides the core implementation for the VDOM (Virtual DOM).
 from jsonschema import validate, Draft4Validator, ValidationError
 
 def toJSON(el, schema=None):
-    if schema:
-        try:
-            validate(instance=el, schema=schema, cls=Draft4Validator)
-        except ValidationError as e:
-            raise ValidationError("Your object didn't match the schema: {}. \n {}".format(schema, e))
-
-    if(type(el) is str):
-        return el
     """Convert an element to JSON
 
     If you wish to validate the JSON, pass in a schema via the schema keyword argument.
     If a schema is provided, this raises a ValidationError if JSON does not match the schema.
     """
     if(type(el) is list):
-        return list(map(toJSON, el))
-    if(hasattr(el, 'tagName') and hasattr(el, 'attributes')):
-        return {
+        json_el = list(map(toJSON, el))
+    elif(hasattr(el, 'tagName') and hasattr(el, 'attributes')):
+        json_el = {
             'tagName': el.tagName,
             'attributes': el.attributes,
             'children': toJSON(el.children)
         }
-    return el
+    else:
+        json_el = el
+
+    if schema:
+        try:
+            validate(instance=json_el, schema=schema, cls=Draft4Validator)
+        except ValidationError as e:
+            raise ValidationError("Your object didn't match the schema: {}. \n {}".format(schema, e))
+
+    return json_el
 
 
 class VDOM():


### PR DESCRIPTION
In order to make #3 easier, it helps to have jsonschema validation as part of the API, this surfaces it on toJSON. 

In the end, we probably want to do this at the time of object creation & modification not when sending a message, but this is a convenient place to put it.