### PR TITLE
create a series of helpers

### DIFF
--- a/vdom/core.py
+++ b/vdom/core.py
@@ -111,6 +111,8 @@ def h(tagName, children=None, attrs=None, **kwargs):
     return el(children, **attrs, **kwargs)
 
 
+# These are left for backwards compatibility, from here on out we should
+# define these in helpers
 h1 = createComponent('h1')
 p = createComponent('p')
 div = createComponent('div')

--- a/vdom/helpers.py
+++ b/vdom/helpers.py
@@ -1,0 +1,33 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+"""
+vdom.helpers
+~~~~~~~~~
+
+Little helper functions for (many of) the HTML Elements.
+
+from vdom.helpers import div, img
+
+div(
+    img(src="http://bit.ly/storybot-vdom")
+)
+
+"""
+
+from .core import createComponent
+
+h1 = createComponent('h1')
+p = createComponent('p')
+div = createComponent('div')
+img = createComponent('img')
+b = createComponent('b')
+
+table = createComponent('table')
+thead = createComponent('thead')
+th = createComponent('th')
+tr = createComponent('tr')
+tbody = createComponent('tbody')
+td = createComponent('td')
+
+input_ = createComponent('input')


### PR DESCRIPTION
Since I keep creating a bunch of helpers for elements at the top of my notebooks, I'd love to have a way to get at all the elements via `vdom.helpers`

```python
from vdom.helpers import div, img

div(
    img(src="http://bit.ly/storybot-vdom")
)
```

This is not an exhaustive collection of HTML Elements, it [_could_ be though if someone wants to make a follow on PR with their favorite HTML elements](https://developer.mozilla.org/en-US/docs/Web/HTML/Element). 😉 