### PR TITLE
[DOCS] rely on helpers directly and use positional syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,15 +14,15 @@ Start with Python code and run it:
 
 ```python
 from IPython.display import display
-from vdom import h1, p, img, div, b
+from vdom.helpers import h1, p, img, div, b
 
 display(
-    div([
+    div(
         h1('Our Incredibly Declarative Example'),
-        p(['Can you believe we wrote this ', b('in Python'), '?']),
+        p('Can you believe we wrote this ', b('in Python'), '?'),
         img(src="https://media.giphy.com/media/xUPGcguWZHRC2HyBRS/giphy.gif"),
-        p(['What will ', b('you'), ' create next?']),
-    ])
+        p('What will ', b('you'), ' create next?'),
+    )
 )
 ```
 


### PR DESCRIPTION
Follow up from #14 mostly, changing the syntax for the README.

Side question: How bad would it be if we always provide the helpers at the top level from `vdom`?