### PR TITLE
ensure void elements don't get children by kwarg

### DIFF
--- a/vdom/core.py
+++ b/vdom/core.py
@@ -140,6 +140,7 @@ def _flatten_children(*children, **kwargs):
     if ('children' in kwargs):
         children = kwargs['children']
     elif children is not None:
+        # If children array is empty, might as well pass None (null in JSON)
         if len(children) == 0:
             children = None
         elif len(children) == 1:
@@ -148,7 +149,11 @@ def _flatten_children(*children, **kwargs):
         elif isinstance(children[0], list):
             # Only one level of flattening, just to match the old API
             children = children[0]
+            # Do we care to map across all the children, making sure to
+            # flatten them too? Or should we just do the else case that
+            # keeps lists of lists of nodes?
         else:
+            # children came in as pure args, our primary case
             children = list(children)
     else:
         # Empty list of children
@@ -170,9 +175,10 @@ def create_component(tagName, allow_children=True):
         """A basic class for a virtual DOM Component"""
 
         def __init__(self, *children, **kwargs):
-            if not allow_children and children:
-                raise ValueError('<{tagName} /> cannot have children'.format(tagName=tagName))
             self.children = _flatten_children(*children, **kwargs)
+            if not allow_children and self.children:
+                raise ValueError('<{tagName} /> cannot have children'.format(
+                    tagName=tagName))
             self.attributes = kwargs
             self.tagName = tagName
             self._schema = VDOM_SCHEMA

--- a/vdom/tests/test_core.py
+++ b/vdom/tests/test_core.py
@@ -37,11 +37,15 @@ def test_flatten_children():
 def test_to_json():
     assert to_json({
         'tagName': 'h1',
-        'attributes': { 'data-test': True },
+        'attributes': {
+            'data-test': True
+        },
         'children': []
     }) == {
         'tagName': 'h1',
-        'attributes': { 'data-test': True},
+        'attributes': {
+            'data-test': True
+        },
         'children': []
     }
 
@@ -81,7 +85,8 @@ def test_to_json():
             ]
         }, {
             'tagName': 'img',
-            'children': None,
+            'children':
+            None,
             'attributes': {
                 'src':
                 'https://media.giphy.com/media/xUPGcguWZHRC2HyBRS/giphy.gif'
@@ -90,31 +95,32 @@ def test_to_json():
         'attributes': {}
     }
 
-_valid_vdom_obj= {'tagName': 'h1', 'children': 'Hey', 'attributes': {}}
+
+_valid_vdom_obj = {'tagName': 'h1', 'children': 'Hey', 'attributes': {}}
+
 
 def test_schema_validation():
     with pytest.raises(ValidationError):
-        test_vdom = VDOM(
-            [_valid_vdom_obj],
-        )
+        test_vdom = VDOM([_valid_vdom_obj], )
 
     # make sure you can pass empty schema
-    assert (
-        VDOM([_valid_vdom_obj], schema = {}).json_contents == [_valid_vdom_obj]
-        )
+    assert (VDOM([_valid_vdom_obj],
+                 schema={}).json_contents == [_valid_vdom_obj])
 
 
 def test_component_allows_children():
     nonvoid = create_component('nonvoid', allow_children=True)
-    test_component = nonvoid(
-        div()
-    )
+    test_component = nonvoid(div())
     assert test_component.children is not None
 
 
 def test_component_disallows_children():
     void = create_component('void', allow_children=False)
     with pytest.raises(ValueError, message='<void /> cannot have children'):
-        void(
-            div()
-        )
+        void(div())
+
+
+def test_component_disallows_children_kwargs():
+    void = create_component('void', allow_children=False)
+    with pytest.raises(ValueError, message='<void /> cannot have children'):
+        void(children=div())


### PR DESCRIPTION
Quick follow on to #40, preventing children from sneaking into void elements (created from our element factories).