### PR TITLE
include button, label, and style components

### DIFF
--- a/vdom/helpers.py
+++ b/vdom/helpers.py
@@ -96,6 +96,8 @@ meter = create_component('meter')
 output = create_component('output')
 progress = create_component('progress')
 input_ = create_component('input', allow_children=False)
+button = create_component('button')
+label = create_component('label')
 
 # Interactive elements
 details = create_component('details')
@@ -103,3 +105,5 @@ dialog = create_component('dialog')
 menu = create_component('menu')
 menuitem = create_component('menuitem')
 summary = create_component('summary')
+
+style = create_component('style')


### PR DESCRIPTION
I wanted to go ahead and take a stab at implementing part of https://github.com/pydata/xarray/issues/1627 with `vdom`, then realized we didn't have the label element or the style element. This introduces those as well as `<button/>` even though we don't have data bindings / callbacks.