### PR TITLE
Use 'warnings' module to provide warnings, rather than print

### DIFF
--- a/vdom/core.py
+++ b/vdom/core.py
@@ -9,6 +9,7 @@ that are renderable in jupyter frontends.
 
 from jsonschema import validate, Draft4Validator, ValidationError
 import json
+import warnings
 
 import os
 import io
@@ -110,8 +111,9 @@ class VDOM(object):
                 to_json(self._obj, schema=value)
             except ValidationError as e:
                 # Don't raise error, but give warning that it is no longer valid
-                print(_validate_err_template.format(value, e))
-                print("VDOM cannot submit a message until this is fixed")
+                warning_message = _validate_err_template.format(value, e)
+                warning_message += "\nVDOM cannot submit a message until this is fixed"
+                warnings.warn(warning_message)
         self._schema = value
 
     @staticmethod
@@ -229,7 +231,7 @@ def create_element(tagName):
 
     This should have been written more like React.createClass
     """
-    print("Warning: createElement is deprecated in favor of createComponent")
+    warnings.warn("Warning: createElement is deprecated in favor of createComponent")
     return create_component(tagName)
 
 

--- a/vdom/tests/test_core.py
+++ b/vdom/tests/test_core.py
@@ -1,13 +1,14 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
-from ..core import _flatten_children, create_component, to_json, VDOM
+from ..core import _flatten_children, create_component, create_element, to_json, VDOM
 from ..helpers import div, p, img, h1, b
 from jsonschema import ValidationError, validate
 import os
 import io
 import json
 import pytest
+import warnings
 
 
 _vdom_schema_file_path = os.path.join(
@@ -129,6 +130,12 @@ def test_component_allows_children():
     test_component = nonvoid(div())
     assert test_component.children is not None
 
+def test_create_element_deprecated():
+    import warnings
+    with warnings.catch_warnings(record=True) as w:
+        warnings.simplefilter("always")
+        create_element('warnme')
+        assert len(w) == 1
 
 def test_component_disallows_children():
     void = create_component('void', allow_children=False)


### PR DESCRIPTION
- Just as visible to the user!
- Can be suppressed if needed