### PR TITLE
Refactor vdom module to be smaller

### DIFF
--- a/example-notebooks/emoji-game.ipynb
+++ b/example-notebooks/emoji-game.ipynb
@@ -1,140 +1,156 @@
 {
-  "cells": [
-    {
-      "cell_type": "code",
-      "source": [
-        "from vdom import VDOM, h1, div, p, b, createComponent\n",
-        "# marquee is deprecated officially by browsers\n",
-        "# we're going to create and use it anyway\n",
-        "marquee = createComponent('marquee')"
-      ],
-      "outputs": [],
-      "execution_count": 2,
-      "metadata": {
-        "collapsed": false,
-        "outputHidden": false,
-        "inputHidden": false
-      }
-    },
-    {
-      "cell_type": "code",
-      "source": [
-        "from collections import Counter\n",
-        "\nwinners = Counter()"
-      ],
-      "outputs": [],
-      "execution_count": 3,
-      "metadata": {
-        "collapsed": false,
-        "outputHidden": false,
-        "inputHidden": false
-      }
-    },
-    {
-      "cell_type": "code",
-      "source": [
-        "import secrets\n",
-        "import time\n",
-        "\n",
-        "winner = \"\"\n",
-        "\n",
-        "# Each player should pick an emoji that you put into this array\n",
-        "choices = [\"🥑\", \"🐱\", \"😻\"]\n",
-        "\n",
-        "game = display(VDOM(h1('GAMETIME')), display_id=\"game\")\n",
-        "\n",
-        "for ii in range(40):\n",
-        "    winner = secrets.choice(choices)\n",
-        "    game.display(\n",
-        "        VDOM(\n",
-        "            marquee(winner, style={ \"fontSize\" : '3em' })\n",
-        "        ),\n",
-        "        update=True\n",
-        "    )\n",
-        "    time.sleep(0.1)\n",
-        "\n",
-        "winners[winner] += 1\n",
-        "    \n",
-        "game.display(VDOM(\n",
-        "    div(\n",
-        "        [\n",
-        "            h1('WINNER ' + winner, style={ \"fontSize\" : '3em' }),\n",
-        "            list(map(lambda i: p(i + ': ' + str(winners[i])), winners))\n",
-        "        ]\n",
-        "    )\n",
-        "), update=True)"
-      ],
-      "outputs": [
-        {
-          "output_type": "display_data",
-          "data": {
-            "application/vdom.v1+json": {
-              "tagName": "div",
-              "attributes": {},
-              "children": [
-                {
-                  "tagName": "h1",
-                  "attributes": {
-                    "style": {
-                      "fontSize": "3em"
-                    }
-                  },
-                  "children": "WINNER 🐱"
-                },
-                [
-                  {
-                    "tagName": "p",
-                    "attributes": {},
-                    "children": "😻: 1"
-                  },
-                  {
-                    "tagName": "p",
-                    "attributes": {},
-                    "children": "🐱: 1"
-                  }
-                ]
-              ]
-            },
-            "text/plain": [
-              "<vdom.core.VDOM at 0x110a86080>"
-            ]
-          },
-          "metadata": {}
-        }
-      ],
-      "execution_count": 5,
-      "metadata": {
-        "collapsed": false,
-        "outputHidden": false,
-        "inputHidden": false
-      }
-    }
-  ],
-  "metadata": {
-    "kernelspec": {
-      "name": "python3",
-      "language": "python",
-      "display_name": "Python 3"
-    },
-    "kernel_info": {
-      "name": "python3"
-    },
-    "language_info": {
-      "name": "python",
-      "version": "3.6.4",
-      "mimetype": "text/x-python",
-      "codemirror_mode": {
-        "name": "ipython",
-        "version": 3
-      },
-      "pygments_lexer": "ipython3",
-      "nbconvert_exporter": "python",
-      "file_extension": ".py"
-    },
-    "nteract": {
-      "version": "0.7.1"
-    }
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {
+    "collapsed": false,
+    "inputHidden": false,
+    "outputHidden": false
+   },
+   "outputs": [],
+   "source": [
+    "from vdom import VDOM, h1, div, p, b, createComponent\n",
+    "# marquee is deprecated officially by browsers\n",
+    "# we're going to create and use it anyway\n",
+    "marquee = createComponent('marquee')"
+   ]
   },
-  "nbformat": 4,
-  "nbformat_minor": 4
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {
+    "collapsed": false,
+    "inputHidden": false,
+    "outputHidden": false
+   },
+   "outputs": [],
+   "source": [
+    "from collections import Counter\n",
+    "\nwinners = Counter()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "metadata": {
+    "collapsed": false,
+    "inputHidden": false,
+    "outputHidden": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "application/vdom.v1+json": {
+       "attributes": {},
+       "children": [
+        {
+         "attributes": {
+          "style": {
+           "fontSize": "3em"
+          }
+         },
+         "children": [
+          "WINNER 🥑"
+         ],
+         "tagName": "h1"
+        },
+        {
+         "attributes": {},
+         "children": [
+          "🥑: 2"
+         ],
+         "tagName": "p"
+        },
+        {
+         "attributes": {},
+         "children": [
+          "🐱: 2"
+         ],
+         "tagName": "p"
+        },
+        {
+         "attributes": {},
+         "children": [
+          "😻: 1"
+         ],
+         "tagName": "p"
+        }
+       ],
+       "tagName": "div"
+      },
+      "text/plain": [
+       "<div />"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "import secrets\n",
+    "import time\n",
+    "\n",
+    "winner = \"\"\n",
+    "\n",
+    "# Each player should pick an emoji that you put into this array\n",
+    "choices = [\"🥑\", \"🐱\", \"😻\"]\n",
+    "\n",
+    "game = display(h1('GAMETIME'), display_id=\"game\")\n",
+    "\n",
+    "for ii in range(40):\n",
+    "    winner = str(secrets.choice(choices))\n",
+    "    game.display(marquee(winner, style={ \"fontSize\" : '3em' }), update=True)\n",
+    "    time.sleep(0.1)\n",
+    "\n",
+    "winners[winner] += 1\n",
+    "    \n",
+    "game.display(\n",
+    "    div(\n",
+    "        h1('WINNER ' + winner, style={ \"fontSize\" : '3em' }),\n",
+    "        *list(map(lambda i: p(i + ': ' + str(winners[i])), winners))\n",
+    "    ), \n",
+    "    update=True\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false,
+    "inputHidden": false,
+    "outputHidden": false
+   },
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernel_info": {
+   "name": "python3"
+  },
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.6.3"
+  },
+  "nteract": {
+   "version": "nteract-on-jupyter@1.6.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
 }

--- a/vdom/core.py
+++ b/vdom/core.py
@@ -8,7 +8,6 @@ that are renderable in jupyter frontends.
 """
 
 from jsonschema import validate, Draft4Validator, ValidationError
-from functools import partial
 import json
 import warnings
 

--- a/vdom/core.py
+++ b/vdom/core.py
@@ -14,6 +14,8 @@ import warnings
 import os
 import io
 
+from vdom.frozendict import FrozenDict
+
 _vdom_schema_file_path = os.path.join(
     os.path.dirname(__file__), "schemas", "vdom_schema_v1.json")
 with io.open(_vdom_schema_file_path, "r") as f:
@@ -74,7 +76,7 @@ class VDOM(object):
             children = vdom_obj.children
             key = vdom_obj.key
         self.tag_name = tag_name
-        self.attributes = attributes if attributes else {}
+        self.attributes = FrozenDict(attributes) if attributes else FrozenDict()
         self.children = tuple(children) if children else tuple()
         self.key = key
 

--- a/vdom/core.py
+++ b/vdom/core.py
@@ -61,7 +61,7 @@ class VDOM(object):
     >>> h1('Hey')
     """
     # This class should only have these 4 attributes
-    __slots__ = ['tag_name', 'attributes', 'children', 'key']
+    __slots__ = ['tag_name', 'attributes', 'children', 'key', '_frozen']
 
     def __init__(self, tag_name, attributes=None, children=None, key=None, schema=None):
         if schema is not None:
@@ -79,6 +79,17 @@ class VDOM(object):
         self.attributes = attributes if attributes else {}
         self.children = children if children else []
         self.key = key
+
+        # mark completion of object creation. Object is immutable from now.
+        self._frozen = True
+
+    def __setattr__(self, attr, value):
+        """
+        Make instances immutable after creation
+        """
+        if hasattr(self, '_frozen') and self._frozen:
+            raise ValueError("Cannot change attribute children of immutable object")
+        super().__setattr__(attr, value)
 
     def to_dict(self):
         vdom_dict = {

--- a/vdom/core.py
+++ b/vdom/core.py
@@ -88,7 +88,7 @@ class VDOM(object):
         Make instances immutable after creation
         """
         if hasattr(self, '_frozen') and self._frozen:
-            raise ValueError("Cannot change attribute children of immutable object")
+            raise AttributeError("Cannot change attribute of immutable object")
         super().__setattr__(attr, value)
 
     def to_dict(self):

--- a/vdom/core.py
+++ b/vdom/core.py
@@ -75,7 +75,7 @@ class VDOM(object):
             key = vdom_obj.key
         self.tag_name = tag_name
         self.attributes = attributes if attributes else {}
-        self.children = children if children else []
+        self.children = tuple(children) if children else tuple()
         self.key = key
 
         # Validate that all children are VDOMs or strings
@@ -161,10 +161,9 @@ def create_component(tag_name, allow_children=True):
             # This supports the use case of div([a, b, c])
             # And allows users to skip the * operator
             if len(children) == 1 and isinstance(children[0], list):
-                children = children[0]
-            else:
-                # Make sure children are a list, rather than a tuple
-                children = list(children)
+                # We want children to be tuples and not lists, so
+                # they can be immutable
+                children = tuple(children[0])
         if 'attributes' in kwargs:
             attributes = kwargs['attributes']
         else:

--- a/vdom/core.py
+++ b/vdom/core.py
@@ -79,7 +79,7 @@ class VDOM(object):
         self.key = key
 
         # Validate that all children are VDOMs or strings
-        if not all([isinstance(c, VDOM) or isinstance(c, str) for c in children]):
+        if not all([isinstance(c, VDOM) or isinstance(c, str) for c in self.children]):
             raise ValueError('Children must be a list of VDOM objects or strings')
 
         # mark completion of object creation. Object is immutable from now.

--- a/vdom/core.py
+++ b/vdom/core.py
@@ -78,6 +78,10 @@ class VDOM(object):
         self.children = children if children else []
         self.key = key
 
+        # Validate that all children are VDOMs or strings
+        if not all([isinstance(c, VDOM) or isinstance(c, str) for c in children]):
+            raise ValueError('Children must be a list of VDOM objects or strings')
+
         # mark completion of object creation. Object is immutable from now.
         self._frozen = True
 

--- a/vdom/core.py
+++ b/vdom/core.py
@@ -162,6 +162,9 @@ def create_component(tag_name, allow_children=True):
             # And allows users to skip the * operator
             if len(children) == 1 and isinstance(children[0], list):
                 children = children[0]
+            else:
+                # Make sure children are a list, rather than a tuple
+                children = list(children)
         if 'attributes' in kwargs:
             attributes = kwargs['attributes']
         else:

--- a/vdom/core.py
+++ b/vdom/core.py
@@ -156,15 +156,20 @@ def create_component(tag_name, allow_children=True):
     def _component(*children, **kwargs):
         if 'children' in kwargs:
             children = kwargs.pop('children')
+        else:
+            # Flatten children under specific circumstances
+            # This supports the use case of div([a, b, c])
+            # And allows users to skip the * operator
+            if len(children) == 1 and isinstance(children[0], list):
+                children = children[0]
         if 'attributes' in kwargs:
             attributes = kwargs['attributes']
         else:
             attributes = dict(**kwargs)
-        if tag_name == 'img':
-            print(children)
         if not allow_children and children:
             # We don't allow children, but some were passed in
             raise ValueError('<{tag_name} /> cannot have children'.format(tag_name=tag_name))
+
         v = VDOM(tag_name, attributes, children)
         return v
     return _component

--- a/vdom/core.py
+++ b/vdom/core.py
@@ -8,6 +8,7 @@ that are renderable in jupyter frontends.
 """
 
 from jsonschema import validate, Draft4Validator, ValidationError
+from functools import partial
 import json
 import warnings
 
@@ -39,12 +40,8 @@ def to_json(el, schema=None):
             json_el['attributes'] = {}
         if 'children' not in el:
             json_el['children'] = []
-    elif (hasattr(el, 'tagName') and hasattr(el, 'attributes')):
-        json_el = {
-            'tagName': el.tagName,
-            'attributes': el.attributes,
-            'children': to_json(el.children)
-        }
+    elif isinstance(el, VDOM):
+        json_el = el.to_dict()
     else:
         json_el = el
 
@@ -56,157 +53,126 @@ def to_json(el, schema=None):
 
     return json_el
 
-
 class VDOM(object):
     """A basic virtual DOM class which allows you to write literal VDOM spec
 
-    >>> VDOM({ 'tagName': 'h1', 'children': 'Hey', 'attributes': {}})
-
-    It's probably better to use `vdom.h` or the helper functions:
-
-    >>> from vdom import h
-    >>> h('h1', 'Hey')
-    <h1 />
+    >>> VDOM(tag_name='h1', children='Hey', attributes: {}})
 
     >>> from vdom.helpers import h1
     >>> h1('Hey')
-
     """
-    _schema = VDOM_SCHEMA
-    _obj = None
+    # This class should only have these 4 attributes
+    __slots__ = ['tag_name', 'attributes', 'children', 'key']
 
-    def __init__(self, obj, schema=None):
-        # we need to assign self.schema first,
-        # because it is used to validate the object
+    def __init__(self, tag_name, attributes=None, children=None, key=None, schema=None):
         if schema is not None:
-            self.schema = schema
-        self.obj = obj
+            warnings.warn('Passing schema param to VDOM constructor is deprecated')
+        if isinstance(tag_name, dict) or isinstance(tag_name, list):
+            # Backwards compatible interface
+            warnings.warn('Passing dict to VDOM constructor is deprecated')
+            value = tag_name
+            vdom_obj = VDOM.from_dict(value)
+            tag_name = vdom_obj.tag_name
+            attributes = vdom_obj.attributes
+            children = vdom_obj.children
+            key = vdom_obj.key
+        self.tag_name = tag_name
+        self.attributes = attributes if attributes else {}
+        self.children = children if children else []
+        self.key = key
+
+    def to_dict(self):
+        vdom_dict = {
+            'tagName': self.tag_name,
+            'attributes': self.attributes
+        }
+        if self.key:
+            vdom_dict['key'] = self.key
+        vdom_dict['children'] = [c.to_dict() if isinstance(c, VDOM) else c for c in self.children]
+        return vdom_dict
+
+    def to_json(self):
+        return json.dumps(self.to_dict())
+
+    def json_contents(self):
+        warnings.warn('VDOM.json_contents method is deprecated, use to_json instead')
+        return self.to_json()
 
     def _repr_mimebundle_(self, include, exclude, **kwargs):
-        return {'application/vdom.v1+json': self.json_contents}
+        return {
+            'application/vdom.v1+json': json.dumps(self.to_dict()),
+            'text/plain': '<{tagName} />'.format(tagName=self.tag_name)
+        }
 
-    @property
-    def json_contents(self):
-        return to_json(self._obj, schema=self._schema)
-
-    @property
-    def obj(self):
-        return self._obj
-
-    @obj.setter
-    def obj(self, value):
-        if to_json(value, schema=self._schema) is not None:
-            self._obj = value
-
-    @property
-    def schema(self):
-        return self._schema
-
-    @schema.setter
-    def schema(self, value):
-        Draft4Validator.check_schema(value)
-        # if object is present, check if schema works, if not give a log
-        if self._obj:
-            try:
-                to_json(self._obj, schema=value)
-            except ValidationError as e:
-                # Don't raise error, but give warning that it is no longer valid
-                warning_message = _validate_err_template.format(value, e)
-                warning_message += "\nVDOM cannot submit a message until this is fixed"
-                warnings.warn(warning_message)
-        self._schema = value
-
-    @staticmethod
-    def validate(value, schema=_schema):
-        to_json(value, schema=schema)
+    @classmethod
+    def from_dict(cls, value):
+        try:
+            validate(instance=value, schema=VDOM_SCHEMA, cls=Draft4Validator)
+        except ValidationError as e:
+            raise ValidationError(_validate_err_template.format(VDOM_SCHEMA, e))
+        return cls(
+            tag_name=value['tagName'],
+            attributes=value.get('attributes', {}),
+            children=[VDOM.from_dict(c) if isinstance(c, dict) else c for c in value.get('children', [])],
+            key=value.get('key')
+        )
 
 
 def _flatten_children(*children, **kwargs):
     '''Flattens *args to allow children to be passed as an array or as
     positional arguments.
-
     >>> _flatten_children("a", "b", "c")
     ["a", "b", "c"]
-
     >>> _flatten_children(["a", "b"])
     ["a", "b"]
-
     >>> _flatten_children(children=["c", "d"])
     ["c", "d"]
-
     >>> _flatten_children()
     []
-
     '''
     # children as keyword argument takes precedence
-    if ('children' in kwargs):
-        children = kwargs['children']
-    elif children is not None:
-        # If children array is empty, might as well pass None (null in JSON)
-        if len(children) == 0:
-            children = None
-        elif len(children) == 1:
-            # Flatten by default
-            children = children[0]
-        elif isinstance(children[0], list):
-            # Only one level of flattening, just to match the old API
-            children = children[0]
-            # Do we care to map across all the children, making sure to
-            # flatten them too? Or should we just do the else case that
-            # keeps lists of lists of nodes?
-        else:
-            # children came in as pure args, our primary case
-            children = list(children)
+    if 'children' in kwargs:
+        return kwargs['children']
+    # If children array is empty, might as well pass None (null in JSON)
+    if len(children) == 0:
+        return None
+    elif isinstance(children[0], list):
+        # Only one level of flattening, just to match the old API
+        return _flatten_children(children[0])
+        # Do we care to map across all the children, making sure to
+        # flatten them too? Or should we just do the else case that
+        # keeps lists of lists of nodes?
+    elif len(children) == 1:
+        # Flatten by default
+        return children[0]
     else:
-        # Empty list of children
-        children = []
-    return children
+        # children came in as pure args, our primary case
+        return list(children)
 
-
-def create_component(tagName, allow_children=True):
-    """Create a component for an HTML Tag
+def create_component(tag_name, allow_children=True):
+    """
+    Create a component for an HTML Tag
 
     Examples:
         >>> marquee = create_component('marquee')
         >>> marquee('woohoo')
         <marquee>woohoo</marquee>
-
     """
-
-    class Component():
-        """A basic class for a virtual DOM Component"""
-
-        def __init__(self, *children, **kwargs):
-            self.children = _flatten_children(*children, **kwargs)
-            if not allow_children and self.children:
-                raise ValueError('<{tagName} /> cannot have children'.format(
-                    tagName=tagName))
-            self.attributes = kwargs
-            self.tagName = tagName
-            self._schema = VDOM_SCHEMA
-
-        def _repr_mimebundle_(self, include, exclude, **kwargs):
-            return {
-                'application/vdom.v1+json': to_json(self, schema=self._schema),
-                'text/plain': '<{tagName} />'.format(tagName=tagName)
-            }
-
-        @property
-        def schema(self):
-            return self._schema
-
-        @schema.setter
-        def schema(self, value):
-            Draft4Validator.check_schema(value)
-            self._schema = value
-
-    Component.__doc__ = """A virtual DOM component for a {tagName} tag
-
-    >>> {tagName}()
-    <{tagName} />
-    """.format(tagName=tagName)
-
-    return Component
+    def _component(*children, **kwargs):
+        if 'children' in kwargs:
+            children = kwargs.pop('children')
+        if 'attributes' in kwargs:
+            attributes = kwargs['attributes']
+        else:
+            attributes = dict(**kwargs)
+        if tag_name == 'img':
+            print(children)
+        if not allow_children and children:
+            # We don't allow children, but some were passed in
+            raise ValueError('<{tag_name} /> cannot have children'.format(tag_name=tag_name))
+        v = VDOM(tag_name, attributes, children)
+        return v
+    return _component
 
 
 def create_element(tagName):

--- a/vdom/core.py
+++ b/vdom/core.py
@@ -118,37 +118,6 @@ class VDOM(object):
         )
 
 
-def _flatten_children(*children, **kwargs):
-    '''Flattens *args to allow children to be passed as an array or as
-    positional arguments.
-    >>> _flatten_children("a", "b", "c")
-    ["a", "b", "c"]
-    >>> _flatten_children(["a", "b"])
-    ["a", "b"]
-    >>> _flatten_children(children=["c", "d"])
-    ["c", "d"]
-    >>> _flatten_children()
-    []
-    '''
-    # children as keyword argument takes precedence
-    if 'children' in kwargs:
-        return kwargs['children']
-    # If children array is empty, might as well pass None (null in JSON)
-    if len(children) == 0:
-        return None
-    elif isinstance(children[0], list):
-        # Only one level of flattening, just to match the old API
-        return _flatten_children(children[0])
-        # Do we care to map across all the children, making sure to
-        # flatten them too? Or should we just do the else case that
-        # keeps lists of lists of nodes?
-    elif len(children) == 1:
-        # Flatten by default
-        return children[0]
-    else:
-        # children came in as pure args, our primary case
-        return list(children)
-
 def create_component(tag_name, allow_children=True):
     """
     Create a component for an HTML Tag

--- a/vdom/core.py
+++ b/vdom/core.py
@@ -89,7 +89,7 @@ class VDOM(object):
         """
         if hasattr(self, '_frozen') and self._frozen:
             raise AttributeError("Cannot change attribute of immutable object")
-        super().__setattr__(attr, value)
+        super(VDOM, self).__setattr__(attr, value)
 
     def to_dict(self):
         vdom_dict = {

--- a/vdom/core.py
+++ b/vdom/core.py
@@ -126,7 +126,7 @@ class VDOM(object):
 
     def _repr_mimebundle_(self, include, exclude, **kwargs):
         return {
-            'application/vdom.v1+json': json.dumps(self.to_dict()),
+            'application/vdom.v1+json': self.to_dict(),
             'text/plain': '<{tagName} />'.format(tagName=self.tag_name)
         }
 

--- a/vdom/frozendict.py
+++ b/vdom/frozendict.py
@@ -1,0 +1,18 @@
+class FrozenDict(dict):
+    """
+    Immutable dictionary subclass
+
+    Once constructed, dictionary can not be mutated without
+    internal python hacks. Useful for enforcing invariants,
+    but not useful for securing anything!
+    """
+    def __readonly__(self, *args, **kwargs):
+        raise ValueError("Can not modify FrozenDict")
+
+    __setitem__ = __readonly__
+    __delitem__ = __readonly__
+    pop = __readonly__
+    popitem = __readonly__
+    clear = __readonly__
+    update = __readonly__
+    setdefault = __readonly__

--- a/vdom/tests/test_core.py
+++ b/vdom/tests/test_core.py
@@ -120,5 +120,5 @@ def test_component_disallows_children_kwargs():
 
 def test_immutable():
     comp = div("Hello")
-    with pytest.raises(ValueError, message="Cannot change attribute children of immutable object"):
+    with pytest.raises(AttributeError):
         comp.children = "Nello"

--- a/vdom/tests/test_core.py
+++ b/vdom/tests/test_core.py
@@ -119,9 +119,16 @@ def test_component_disallows_children_kwargs():
         void(children=div())
 
 def test_immutable():
-    comp = div("Hello")
     with pytest.raises(AttributeError):
+        comp = div("Hello")
         comp.children = "Nello"
+
+def test_immutable_children():
+    comp = div(h1("hello"))
+    with pytest.raises(AttributeError):
+        comp.children.append(h1("boo"))
+    with pytest.raises(TypeError):
+        comp.children[0] = h1("boo")
 
 def test_invalid_children():
     with pytest.raises(ValueError):

--- a/vdom/tests/test_core.py
+++ b/vdom/tests/test_core.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
-from ..core import _flatten_children, create_component, create_element, to_json, VDOM
+from ..core import create_component, create_element, to_json, VDOM
 from ..helpers import div, p, img, h1, b
 from jsonschema import ValidationError, validate
 import os

--- a/vdom/tests/test_core.py
+++ b/vdom/tests/test_core.py
@@ -130,6 +130,11 @@ def test_immutable_children():
     with pytest.raises(TypeError):
         comp.children[0] = h1("boo")
 
+def test_immutable_attributes():
+    comp = div(h1("hello"))
+    with pytest.raises(ValueError):
+        comp.attributes['class'] = 'something'
+
 def test_invalid_children():
     with pytest.raises(ValueError):
         comp = div(5)

--- a/vdom/tests/test_core.py
+++ b/vdom/tests/test_core.py
@@ -122,3 +122,7 @@ def test_immutable():
     comp = div("Hello")
     with pytest.raises(AttributeError):
         comp.children = "Nello"
+
+def test_invalid_children():
+    with pytest.raises(ValueError):
+        comp = div(5)

--- a/vdom/tests/test_core.py
+++ b/vdom/tests/test_core.py
@@ -117,3 +117,8 @@ def test_component_disallows_children_kwargs():
     void = create_component('void', allow_children=False)
     with pytest.raises(ValueError, message='<void /> cannot have children'):
         void(children=div())
+
+def test_immutable():
+    comp = div("Hello")
+    with pytest.raises(ValueError, message="Cannot change attribute children of immutable object"):
+        comp.children = "Nello"

--- a/vdom/tests/test_core.py
+++ b/vdom/tests/test_core.py
@@ -16,32 +16,6 @@ _vdom_schema_file_path = os.path.join(
 with io.open(_vdom_schema_file_path, "r") as f:
     VDOM_SCHEMA = json.load(f)
 
-def test_flatten_children():
-    # when the first argument is an array, interpret it as the primary argument
-    assert _flatten_children([1, 2, 3]) == [1, 2, 3]
-    # otherwise positional arguments are fine
-    assert _flatten_children(1, 2, 3) == [1, 2, 3]
-    # keyword argument of children is ok too
-    assert _flatten_children(children=[1, 2, 3]) == [1, 2, 3]
-
-    # precedence tests
-    # kwargs[children] is highest priority
-    assert _flatten_children([1], 2, children=[3]) == [3]
-    # array as first argument second highest priority
-    assert _flatten_children([1], 2) == [1]
-    # otherwise, positional arguments are the default
-    assert _flatten_children(2, 3) == [2, 3]
-
-    # an empty array returns an empty array
-    assert _flatten_children([]) == []
-    # with no arguments, we get a null
-    assert _flatten_children() == None
-
-    # If the first argument is None, we assume they explicitly wanted a
-    # null element for a VDOMEl (this is ok)
-    assert _flatten_children(None) == None
-    assert _flatten_children(None, 1, None) == [None, 1, None]
-
 
 def test_to_json():
     assert to_json({
@@ -60,11 +34,11 @@ def test_to_json():
 
     assert to_json(div(h1('Our Incredibly Declarative Example'))) == {
         'tagName': 'div',
-        'children': {
+        'children': [{
             'tagName': 'h1',
-            'children': 'Our Incredibly Declarative Example',
+            'children': ['Our Incredibly Declarative Example'],
             'attributes': {}
-        },
+        }],
         'attributes': {}
     }
 
@@ -79,7 +53,7 @@ def test_to_json():
         'div',
         'children': [{
             'tagName': 'h1',
-            'children': 'Our Incredibly Declarative Example',
+            'children': ['Our Incredibly Declarative Example'],
             'attributes': {}
         }, {
             'tagName':
@@ -88,14 +62,13 @@ def test_to_json():
             'children': [
                 'Can you believe we wrote this ', {
                     'tagName': 'b',
-                    'children': 'in Python',
+                    'children': ['in Python'],
                     'attributes': {}
                 }, '?'
             ]
         }, {
             'tagName': 'img',
-            'children':
-            None,
+            'children': [],
             'attributes': {
                 'src':
                 'https://media.giphy.com/media/xUPGcguWZHRC2HyBRS/giphy.gif'
@@ -113,9 +86,6 @@ def test_schema_validation():
     with pytest.raises(ValidationError):
         test_vdom = VDOM([_valid_vdom_obj], )
 
-    # make sure you can pass empty schema
-    assert (VDOM([_valid_vdom_obj],
-                 schema={}).json_contents == [_valid_vdom_obj])
   
     # check that you can pass a valid schema
     assert (VDOM(_valid_vdom_obj, schema=VDOM_SCHEMA))


### PR DESCRIPTION
The code is now shorter and (arguably) more 'pythonic'.

Major structural changes:

1. VDOM objects are no longer containers for unstructured
   dicts. They have a fixed set of attributes (tag_name,
   children, key and attributes). This is enforced
   with `__slots__`.
2. A new Component class is not created when calling
   `create_component`. Instead, a partial of the
   VDOM constructor is created.
3. The JSON Schema is only checked when a VDOM object is
   being deserialized from JSON.

Major behavior changes:

1. Children are no longer 'flattened'. Node children will always
   be a list of 0 or more elements. This is compliant with the
   spec. Tests have been modified to accomodate this.
2. Do not support passing arbitrary schemas to VDOM constructor.
   VDOM is a structured object now, so this is unnecessary.