### PR TITLE
Explicitly include package data in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -28,5 +28,7 @@ setup(
     url='https://github.com/nteract/vdom',
     packages=['vdom'],
     package_data={'vdom': ['schemas/vdom_schema_v0.json']},
+    include_package_data=True,
     install_requires=install_requires,
-    extras_require=extras_require)
+    extras_require=extras_require,
+)


### PR DESCRIPTION
Otherwise the vdom json schema file does not seem to get
included.

You get an error message like the following when trying to use it:

```
In [1]: import vdom
---------------------------------------------------------------------------
FileNotFoundError                         Traceback (most recent call last)
<ipython-input-1-d9e1c69bbbf7> in <module>()
----> 1 import vdom

~/code/vdom/test/lib/python3.6/site-packages/vdom/__init__.py in <module>()
----> 1 from .core import *
      2 from .helpers import *
      3 
      4 from ._version import get_versions
      5 __version__ = get_versions()['version']

~/code/vdom/test/lib/python3.6/site-packages/vdom/core.py in <module>()
     37 _vdom_schema_file_path = os.path.join(
     38     os.path.dirname(__file__), "schemas", "vdom_schema_v1.json")
---> 39 with io.open(_vdom_schema_file_path, "r") as f:
     40     VDOM_SCHEMA = json.load(f)
     41 _validate_err_template = "Your object didn't match the schema: {}. \n {}"

FileNotFoundError: [Errno 2] No such file or directory: '/home/yuvipanda/code/vdom/test/lib/python3.6/site-packages/vdom/schemas/vdom_schema_v1.json'

```