### PR TITLE
Improve repr html

### DIFF
--- a/vdom/core.py
+++ b/vdom/core.py
@@ -12,6 +12,7 @@ from jsonschema import validate, Draft4Validator, ValidationError
 import json
 import warnings
 import re
+import itertools
 
 import os
 from collections import OrderedDict
@@ -126,7 +127,7 @@ class VDOM(object):
         self.children = tuple(children) if children else tuple()
         self.key = key
         # Sort attributes so our outputs are predictable
-        self.style = FrozenDict(sorted(s for s in convert_style_names(style.items()))) if style else FrozenDict()
+        self.style = FrozenDict(sorted(style.items())) if style else FrozenDict()
 
         # Validate that all children are VDOMs or strings
         if not all(isinstance(c, (VDOM, string_types[:])) for c in self.children):
@@ -199,7 +200,8 @@ class VDOM(object):
         """
         Return inline CSS from CSS key / values
         """
-        return "; ".join(['{}: {}'.format(k, v) for k, v in style.items()])
+        return "; ".join(['{}: {}'.format(k, v) 
+                          for k, v in convert_style_names(style.items())])
 
     def _repr_html_(self):
         """

--- a/vdom/core.py
+++ b/vdom/core.py
@@ -202,8 +202,7 @@ class VDOM(object):
         """
         Return inline CSS from CSS key / values
         """
-        return "; ".join(['{}: {}'.format(k, v)
-                          for k, v in convert_style_names(style.items())])
+        return "; ".join(['{}: {}'.format(convert_style_key(k), v) for k, v in style.items()])
 
     def _repr_html_(self):
         """
@@ -267,11 +266,13 @@ upper = re.compile(r'[A-Z]')
 def _upper_replace(matchobj):
     return '-' + matchobj.group(0).lower()
 
-def convert_style_names(style):
+def convert_style_key(key):
     """Converts style names from DOM to css styles.
+
+    >>> convert_style_key("backgroundColor")
+    "background-color"
     """
-    for k, v in style:
-        yield re.sub(upper, _upper_replace, k), v
+    return re.sub(upper, _upper_replace, key)
 
 
 def create_component(tag_name, allow_children=True):

--- a/vdom/core.py
+++ b/vdom/core.py
@@ -177,8 +177,9 @@ class VDOM(object):
         return attributes
 
     def to_dict(self):
-
-        attr_tuple = (self.attributes.items(), {"style": self.style}.items()) if self.style else (self.attributes.items(),)
+        """Converts VDOM object to a dictionary that passes our schema
+        """
+        attr_tuple = (self.attributes.items(), {"style": dict(self.style)}.items()) if self.style else (self.attributes.items(),)
         vdom_dict = {
             'tagName': self.tag_name,
             'attributes': dict(itertools.chain.from_iterable(attr_tuple))

--- a/vdom/core.py
+++ b/vdom/core.py
@@ -177,10 +177,11 @@ class VDOM(object):
         return attributes
 
     def to_dict(self):
+
+        attr_tuple = (self.attributes.items(), {"style": self.style}.items()) if self.style else (self.attributes.items(),)
         vdom_dict = {
             'tagName': self.tag_name,
-            'attributes': dict(itertools.chain(self.attributes.items(),
-                                               {"style": self.style}.items()))
+            'attributes': dict(itertools.chain.from_iterable(attr_tuple))
         }
         if self.key:
             vdom_dict['key'] = self.key

--- a/vdom/core.py
+++ b/vdom/core.py
@@ -46,7 +46,7 @@ _validate_err_template = "Your object didn't match the schema: {}. \n {}"
 
 def create_event_handler(event_name, handler):
     """Register a comm and return a serializable object with target name"""
-    
+
     target_name = '{hash}_{event_name}'.format(hash=str(int(time.time())), event_name=event_name)
 
     def handle_comm_opened(comm, msg):
@@ -56,13 +56,13 @@ def create_event_handler(event_name, handler):
             event = json.loads(data)
             return_value = handler(event)
             if return_value:
-                comm.send(return_value) 
+                comm.send(return_value)
 
         comm.send('Comm target "{target_name}" registered by vdom'.format(target_name=target_name))
-    
+
     # Register a new comm for this event handler
     get_ipython().kernel.comm_manager.register_target(target_name, handle_comm_opened)
-    
+
     # Return a serialized object
     return {
         'target_name': target_name
@@ -145,7 +145,7 @@ class VDOM(object):
 
         if schema is not None:
             self.validate(schema)
-    
+
 
     def __setattr__(self, attr, value):
         """
@@ -175,11 +175,12 @@ class VDOM(object):
             else:
                 attributes[key] = value
         return attributes
-    
+
     def to_dict(self):
         vdom_dict = {
             'tagName': self.tag_name,
-            'attributes': self.encode_attributes()
+            'attributes': dict(itertools.chain(self.attributes.items(),
+                                               {"style": self.style}.items()))
         }
         if self.key:
             vdom_dict['key'] = self.key
@@ -200,7 +201,7 @@ class VDOM(object):
         """
         Return inline CSS from CSS key / values
         """
-        return "; ".join(['{}: {}'.format(k, v) 
+        return "; ".join(['{}: {}'.format(k, v)
                           for k, v in convert_style_names(style.items())])
 
     def _repr_html_(self):
@@ -270,8 +271,8 @@ def convert_style_names(style):
     """
     for k, v in style:
         yield re.sub(upper, _upper_replace, k), v
-            
-    
+
+
 def create_component(tag_name, allow_children=True):
     """
     Create a component for an HTML Tag

--- a/vdom/core.py
+++ b/vdom/core.py
@@ -214,7 +214,10 @@ class VDOM(object):
 
             for k, v in self.attributes.items():
                 # Important values are in double quotes - cgi.escape only escapes double quotes, not single quotes!
-                out.write(' {key}="{value}"'.format(key=escape(k), value=escape(v)))
+                if isinstance(v, string_types):
+                    out.write(' {key}="{value}"'.format(key=escape(k), value=escape(v)))
+                if isinstance(v, bool) and v:
+                    out.write(' {key}'.format(key=escape(k)))
             out.write('>')
 
             for c in self.children:

--- a/vdom/tests/test_core.py
+++ b/vdom/tests/test_core.py
@@ -33,17 +33,17 @@ def test_css():
                  'backgroundColor': 'pink',
                  'color': 'white',
                  # Quotes should be entity escaped
-                 'font-family': "'something something'"
+                 'fontFamily': "'something something'"
              },
              title='Test'
          )
     assert el.to_html() == '<div style="background-color: pink; color: white; font-family: &#x27;something something&#x27;" title="Test"><p>Hello world</p></div>'
     assert el.to_dict() == {'attributes': {'style': {'backgroundColor': 'pink',
                                                      'color': 'white',
-                                                     'font-family': "'something something'"},
+                                                     'fontFamily': "'something something'"},
                                            'title': 'Test'},
-                            'children': [{'attributes': {}, 
-                                          'children': ['Hello world'], 
+                            'children': [{'attributes': {},
+                                          'children': ['Hello world'],
                                           'tagName': 'p'}],
                             'tagName': 'div'}
 
@@ -167,7 +167,7 @@ def test_immutable_attributes():
 def test_invalid_children():
     with pytest.raises(ValueError):
         comp = div(5)
-        
+
 def test_convert_style_key():
     assert convert_style_key("backgroundColor") == "background-color"
     assert convert_style_key("preserveAspectRatio") == "preserve-aspect-ratio"

--- a/vdom/tests/test_core.py
+++ b/vdom/tests/test_core.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
-from ..core import create_component, create_element, to_json, VDOM
+from ..core import create_component, create_element, to_json, VDOM, convert_style_key
 from ..helpers import div, p, img, h1, b
 from jsonschema import ValidationError, validate
 import os
@@ -27,16 +27,25 @@ def test_to_html_escaping():
     assert div(p("Hello world<script>evil</script>", title='something')).to_html() == '<div><p title="something">Hello world&lt;script&gt;evil&lt;/script&gt;</p></div>'
 
 def test_css():
-    assert div(
-        p('Hello world'),
-        style={
-            'backgroundColor': 'pink',
-            'color': 'white',
-            # Quotes should be entity escaped
-            'font-family': "'something something'"
-        },
-        title='Test'
-    ).to_html() == '<div style="background-color: pink; color: white; font-family: &#x27;something something&#x27;" title="Test"><p>Hello world</p></div>'
+    el = div(
+             p('Hello world'),
+             style={
+                 'backgroundColor': 'pink',
+                 'color': 'white',
+                 # Quotes should be entity escaped
+                 'font-family': "'something something'"
+             },
+             title='Test'
+         )
+    assert el.to_html() == '<div style="background-color: pink; color: white; font-family: &#x27;something something&#x27;" title="Test"><p>Hello world</p></div>'
+    assert el.to_dict() == {'attributes': {'style': {'backgroundColor': 'pink',
+                                                     'color': 'white',
+                                                     'font-family': "'something something'"},
+                                           'title': 'Test'},
+                            'children': [{'attributes': {}, 
+                                          'children': ['Hello world'], 
+                                          'tagName': 'p'}],
+                            'tagName': 'div'}
 
 def test_to_json():
     assert to_json({

--- a/vdom/tests/test_core.py
+++ b/vdom/tests/test_core.py
@@ -159,3 +159,6 @@ def test_invalid_children():
     with pytest.raises(ValueError):
         comp = div(5)
         
+def test_convert_style_key():
+    assert convert_style_key("backgroundColor") == "background-color"
+    assert convert_style_key("preserveAspectRatio") == "preserve-aspect-ratio"

--- a/vdom/tests/test_core.py
+++ b/vdom/tests/test_core.py
@@ -30,7 +30,7 @@ def test_css():
     assert div(
         p('Hello world'),
         style={
-            'background-color': 'pink',
+            'backgroundColor': 'pink',
             'color': 'white',
             # Quotes should be entity escaped
             'font-family': "'something something'"
@@ -158,3 +158,4 @@ def test_immutable_attributes():
 def test_invalid_children():
     with pytest.raises(ValueError):
         comp = div(5)
+        


### PR DESCRIPTION
Our example notebooks are broken in a couple of ways described in #67. 

This closes the first two of those bullet points. 

However, I wanted some feedback about which level we wanted to do the transform to css-style style names. Right now it's happening at initialization. We could keep them as is and only do it when rendering to html. 

Thoughts?