### PR TITLE
Add the v1 schema to the manifest.in.

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,4 @@
 include versioneer.py
 include vdom/_version.py
 include vdom/schemas/vdom_schema_v0.json
+include vdom/schemas/vdom_schema_v1.json


### PR DESCRIPTION
Add the v1 schema to the manifest because:

> FileNotFoundError: [Errno 2] No such file or directory: '.../lib/python3.6/site-packages/vdom/schemas/vdom_schema_v1.json'