### PR TITLE
Fix merge conflict between #44 and #68

### DIFF
--- a/vdom/core.py
+++ b/vdom/core.py
@@ -44,10 +44,10 @@ with io.open(_vdom_schema_file_path, "r") as f:
     VDOM_SCHEMA = json.load(f)
 _validate_err_template = "Your object didn't match the schema: {}. \n {}"
 
-def create_event_handler(event_name, handler):
+def create_event_handler(event_type, handler):
     """Register a comm and return a serializable object with target name"""
 
-    target_name = '{hash}_{event_name}'.format(hash=str(int(time.time())), event_name=event_name)
+    target_name = '{hash}_{event_type}'.format(hash=hash(handler), event_type=event_type)
 
     def handle_comm_opened(comm, msg):
         @comm.on_msg
@@ -61,7 +61,8 @@ def create_event_handler(event_name, handler):
         comm.send('Comm target "{target_name}" registered by vdom'.format(target_name=target_name))
 
     # Register a new comm for this event handler
-    get_ipython().kernel.comm_manager.register_target(target_name, handle_comm_opened)
+    if get_ipython():
+        get_ipython().kernel.comm_manager.register_target(target_name, handle_comm_opened)
 
     # Return a serialized object
     return {

--- a/vdom/core.py
+++ b/vdom/core.py
@@ -179,10 +179,12 @@ class VDOM(object):
     def to_dict(self):
         """Converts VDOM object to a dictionary that passes our schema
         """
-        attr_tuple = (self.attributes.items(), {"style": dict(self.style)}.items()) if self.style else (self.attributes.items(),)
+        attributes = self.encode_attributes()
+        if self.style:
+            attributes.update({"style": dict(self.style.items())})
         vdom_dict = {
             'tagName': self.tag_name,
-            'attributes': dict(itertools.chain.from_iterable(attr_tuple))
+            'attributes': attributes
         }
         if self.key:
             vdom_dict['key'] = self.key

--- a/vdom/tests/test_core.py
+++ b/vdom/tests/test_core.py
@@ -2,7 +2,7 @@
 # -*- coding: utf-8 -*-
 
 from ..core import create_component, create_element, to_json, VDOM, convert_style_key
-from ..helpers import div, p, img, h1, b
+from ..helpers import div, p, img, h1, b, button
 from jsonschema import ValidationError, validate
 import os
 import io
@@ -28,14 +28,14 @@ def test_to_html_escaping():
 
 def test_css():
     el = div(
-             p('Hello world'),
-             style={
-                 'backgroundColor': 'pink',
-                 'color': 'white',
-                 # Quotes should be entity escaped
-                 'fontFamily': "'something something'"
-             },
-             title='Test'
+            p('Hello world'),
+            style={
+                'backgroundColor': 'pink',
+                'color': 'white',
+                # Quotes should be entity escaped
+                'fontFamily': "'something something'"
+            },
+            title='Test'
          )
     assert el.to_html() == '<div style="background-color: pink; color: white; font-family: &#x27;something something&#x27;" title="Test"><p>Hello world</p></div>'
     assert el.to_dict() == {'attributes': {'style': {'backgroundColor': 'pink',
@@ -46,6 +46,22 @@ def test_css():
                                           'children': ['Hello world'],
                                           'tagName': 'p'}],
                             'tagName': 'div'}
+
+def test_event_handler():
+    def handle_click(event):
+        print(event)
+    
+    el = button(
+        'click me', 
+        onClick=handle_click
+    )
+
+    assert el.to_html() == '<button>click me</button>'
+    assert el.to_dict() == {'attributes': {'onClick': {
+                                'target_name': '{hash}_onClick'.format(hash=hash(handle_click))
+                            }},
+                            'children': ['click me'],
+                            'tagName': 'button'}
 
 def test_to_json():
     assert to_json({


### PR DESCRIPTION
Closes https://github.com/nteract/vdom/issues/69

I don't understand the subtleties of `itertools.chain.from_iterable`, but my understanding of the intention here was to separate `style` from attributes until `to_dict` is called, at which point merge them with attributes. This just skips the tuple part and merges `self.style` with attributes (resulting from `self.encode_attributes` which does the event handler stuff).