### PR TITLE
Move event handlers out of attributes

### DIFF
--- a/vdom/core.py
+++ b/vdom/core.py
@@ -65,9 +65,7 @@ def create_event_handler(event_type, handler):
         get_ipython().kernel.comm_manager.register_target(target_name, handle_comm_opened)
 
     # Return a serialized object
-    return {
-        'target_name': target_name
-    }
+    return target_name
 
 def to_json(el, schema=None):
     """Convert an element to VDOM JSON

--- a/vdom/schemas/vdom_schema_v1.json
+++ b/vdom/schemas/vdom_schema_v1.json
@@ -17,6 +17,9 @@
           "attributes": {
             "type": "object"   
           },
+          "eventHandlers": {
+            "type": "object"   
+          },
           "key": {
             "oneOf": [{"type": "number"}, {"type": "string"}, {"type": "null"}]
           }

--- a/vdom/tests/test_core.py
+++ b/vdom/tests/test_core.py
@@ -57,7 +57,8 @@ def test_event_handler():
     )
 
     assert el.to_html() == '<button>click me</button>'
-    assert el.to_dict() == {'attributes': {'onClick': '{hash}_onClick'.format(hash=hash(handle_click))},
+    assert el.to_dict() == {'attributes': {},
+                            'eventHandlers': {'onClick': '{hash}_onClick'.format(hash=hash(handle_click))},
                             'children': ['click me'],
                             'tagName': 'button'}
 

--- a/vdom/tests/test_core.py
+++ b/vdom/tests/test_core.py
@@ -57,9 +57,7 @@ def test_event_handler():
     )
 
     assert el.to_html() == '<button>click me</button>'
-    assert el.to_dict() == {'attributes': {'onClick': {
-                                'target_name': '{hash}_onClick'.format(hash=hash(handle_click))
-                            }},
+    assert el.to_dict() == {'attributes': {'onClick': '{hash}_onClick'.format(hash=hash(handle_click))},
                             'children': ['click me'],
                             'tagName': 'button'}
 


### PR DESCRIPTION
Closes https://github.com/nteract/vdom/issues/70

This leaves the UX the same:

```py
my_button = button('Click me', onClick=handle_click)
```

However, it moves event handlers out of `VDOM.attributes` so that they can be handled separately from regular attributes. 

This also modifies the message spec to make `eventHandlers` a top-level property. 

A couple point to discuss:

* Should `event_handlers` be a new argument in `VDOM`
* There is duplicate logic for extracting event handlers from attributes in `from_dict` and `create_component`. Same for extracting style from attributes. Perhaps we should revisit how this is done?
* Event handlers are extracted in `from_dict` and `create_component` (on creation) and serialized on `VDOM.to_dict`
* When serializing event handlers, it returns a target name string vs. object now