### PR TITLE
Make it so include and exclude are optional arguments in _repr_mimebundle_

### DIFF
--- a/vdom/core.py
+++ b/vdom/core.py
@@ -247,7 +247,7 @@ class VDOM(object):
 
             return out.getvalue()
 
-    def _repr_mimebundle_(self, include, exclude, **kwargs):
+    def _repr_mimebundle_(self, include=None, exclude=None, **kwargs):
         return {'application/vdom.v1+json': self.to_dict(), 'text/plain': self.to_html()}
 
     @classmethod


### PR DESCRIPTION
This improves the API for our _repr_mimebundle_ call, bringing it into consistency with IPython's `Image._repr_mimebundle_` method : https://github.com/ipython/ipython/blob/332309e3d1c5d807749ae780bd8c65ee145554c7/IPython/core/display.py#L1237