### PR TITLE
Improve from_dict

### DIFF
--- a/vdom/core.py
+++ b/vdom/core.py
@@ -263,8 +263,8 @@ class VDOM(object):
             # Make a copy of attributes, since we're gonna remove styles from it
             attributes = attributes.copy()
             style = attributes.pop('style')
-        for key, value in attributes.items():
-            if callable(value):
+        for key, val in attributes.items():
+            if callable(val):
                 attributes = attributes.copy()
                 if event_handlers == None:
                     event_handlers = {key: attributes.pop(key)}

--- a/vdom/tests/test_core.py
+++ b/vdom/tests/test_core.py
@@ -127,6 +127,45 @@ def test_to_json():
     }
 
 
+def test_VDOM_from_dict():
+    assert (
+        VDOM.from_dict(
+            {
+                'tagName': 'div',
+                'children': [
+                    {
+                        'tagName': 'h1',
+                        'children': ['Our Incredibly Declarative Example'],
+                        'attributes': {},
+                    },
+                    {
+                        'tagName': 'p',
+                        'attributes': {},
+                        'children': [
+                            'Can you believe we wrote this ',
+                            {'tagName': 'b', 'children': ['in Python'], 'attributes': {}},
+                            '?',
+                        ],
+                    },
+                    {
+                        'tagName': 'img',
+                        'children': [],
+                        'attributes': {
+                            'src': 'https://media.giphy.com/media/xUPGcguWZHRC2HyBRS/giphy.gif'
+                        },
+                    },
+                ],
+                'attributes': {},
+            }
+        ).to_json()
+        == div(
+            h1('Our Incredibly Declarative Example'),
+            p('Can you believe we wrote this ', b('in Python'), '?'),
+            img(src="https://media.giphy.com/media/xUPGcguWZHRC2HyBRS/giphy.gif"),
+        ).to_json()
+    )
+
+
 _valid_vdom_obj = {'tagName': 'h1', 'children': 'Hey', 'attributes': {}}
 _invalid_vdom_obj = {'tagName': 'h1', 'children': [{'randomProperty': 'randomValue'}]}
 


### PR DESCRIPTION
Currently `VDOM.from_dict` is broken because of reusing its parameter name as an iterator variable in one of its for loops. This fixes that and adds a test to make sure that this works going forward.

We should probably add an equality operator at some point between VDOM objects, but that's out of scope for this PR.