### PR TITLE
[MRG] Remove unneeded postBuild

### DIFF
--- a/postBuild
+++ b/postBuild
@@ -1,2 +1,0 @@
-# Install vdom in library mode
-pip install -e .


### PR DESCRIPTION
Binder now runs `pip install .` automatically when there is a setup.py