### PR TITLE
moved imports to the top to avoid execution order error

### DIFF
--- a/example-notebooks/sparklines-svg-computing.ipynb
+++ b/example-notebooks/sparklines-svg-computing.ipynb
@@ -18,7 +18,9 @@
       "source": [
         "from vdom import *\n",
         "from vdom.svg import *\n",
-        "from functools import reduce"
+        "from functools import reduce\n",
+        "import random\n",
+        "import time",
       ],
       "outputs": [],
       "execution_count": null,
@@ -99,9 +101,6 @@
     {
       "cell_type": "code",
       "source": [
-        "import random\n",
-        "import time\n",
-        "\n",
         "def minichart(lines, title=\"\"):\n",
         "    # if lines is a 1D array, we'll assume an equidistant x array\n",
         "    height = 120\n",


### PR DESCRIPTION
random is called before it is imported resulting in an error.  To resolve this I moved the imports to the top, and brought the import of time up as well.

Note: The error was "NameError: name 'random' is not defined"